### PR TITLE
Add bot API URL config

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,8 @@ def create_app():
     app = Flask(__name__, instance_relative_config=True)
     # Load configuration from secret_config.py only (simplified single-file config)
     app.config.from_pyfile('secret_config.py')
+    # Provide default for bot API URL if not set
+    app.config.setdefault('BOT_API_URL', 'http://localhost:8000')
     
     # Ensure instance directories exist
     os.makedirs(os.path.join(app.instance_path, 'campaigns'), exist_ok=True)
@@ -116,7 +118,7 @@ def root():
         # Fetch roles from bot API
         import requests
         try:
-            resp = requests.get(f"http://localhost:8000/roles/{user_id}", timeout=2)
+            resp = requests.get(f"{current_app.config['BOT_API_URL']}/roles/{user_id}", timeout=2)
             resp.raise_for_status()
             response_data = resp.json()
             user_roles = response_data.get("roles", [])
@@ -254,7 +256,7 @@ def profile():
     # Fetch Discord roles for this user
     import requests
     try:
-        resp = requests.get(f"http://localhost:8000/roles/{user_id}", timeout=2)
+        resp = requests.get(f"{current_app.config['BOT_API_URL']}/roles/{user_id}", timeout=2)
         resp.raise_for_status()
         response_data = resp.json()
         user_roles = response_data.get("roles", [])

--- a/features/signup/routes.py
+++ b/features/signup/routes.py
@@ -43,7 +43,9 @@ def dashboard():
     # Fetch roles from your bot API
     try:
         logger.debug(f"Fetching roles and nickname for user ID {user_id}")
-        resp = requests.get(f"http://localhost:8000/roles/{user_id}", timeout=2)
+        resp = requests.get(
+            f"{current_app.config['BOT_API_URL']}/roles/{user_id}", timeout=2
+        )
         resp.raise_for_status()
         response_data = resp.json()
         user_roles = response_data.get("roles", [])
@@ -111,7 +113,9 @@ def signup_mission(mission_id):
     
     # Get roles and nickname
     try:
-        resp = requests.get(f"http://localhost:8000/roles/{user_id}", timeout=2)
+        resp = requests.get(
+            f"{current_app.config['BOT_API_URL']}/roles/{user_id}", timeout=2
+        )
         resp.raise_for_status()
         response_data = resp.json()
         user_roles = response_data.get("roles", [])
@@ -271,7 +275,9 @@ def process_signup(mission_id):
     
     # Get nickname
     try:
-        resp = requests.get(f"http://localhost:8000/roles/{user_id}", timeout=2)
+        resp = requests.get(
+            f"{current_app.config['BOT_API_URL']}/roles/{user_id}", timeout=2
+        )
         resp.raise_for_status()
         response_data = resp.json()
         nickname = response_data.get("nickname", user.username)
@@ -334,7 +340,9 @@ def create_new_flight(mission_id):
     user_id = str(user.id)
     # Use display_name for all flight creation/joining
     try:
-        resp = requests.get(f"http://localhost:8000/roles/{user_id}", timeout=2)
+        resp = requests.get(
+            f"{current_app.config['BOT_API_URL']}/roles/{user_id}", timeout=2
+        )
         resp.raise_for_status()
         response_data = resp.json()
         nickname = response_data.get("nickname", user.username)
@@ -447,7 +455,9 @@ def join_existing_flight(mission_id, flight_id):
     user = discord.fetch_user()
     user_id = str(user.id)
     try:
-        resp = requests.get(f"http://localhost:8000/roles/{user_id}", timeout=2)
+        resp = requests.get(
+            f"{current_app.config['BOT_API_URL']}/roles/{user_id}", timeout=2
+        )
         resp.raise_for_status()
         response_data = resp.json()
         nickname = response_data.get("nickname", user.username)

--- a/instance/secret_config.py.example
+++ b/instance/secret_config.py.example
@@ -27,3 +27,6 @@ RED_TEAM_ROLE = ''     # Red Team role ID
 BLUE_TEAM_ROLE = ''    # Blue Team role ID
 ADMIN_ROLE = ''        # Admin role ID
 MISSION_MAKER_ROLE = '' # Mission Maker role ID
+
+# Base URL for the Discord bot API
+BOT_API_URL = 'http://localhost:8000'


### PR DESCRIPTION
## Summary
- default BOT_API_URL in `secret_config.py.example`
- load BOT_API_URL into the Flask app configuration
- use the configured BOT_API_URL for requests in the app and signup feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68436546a380832aa7722d32d16a7f96