### PR TITLE
Fix save_json argument order

### DIFF
--- a/features/campaigns/routes.py
+++ b/features/campaigns/routes.py
@@ -308,5 +308,5 @@ def add_squadron_to_campaign():
 
     # Add or update the squadron in the dict
     campaign_squadrons[squadron_id] = new_entry
-    save_json({'squadrons': campaign_squadrons}, squadrons_path)
+    save_json(squadrons_path, {'squadrons': campaign_squadrons})
     return jsonify({"success": True, "squadron": new_entry})


### PR DESCRIPTION
## Summary
- adjust argument order in `add_squadron_to_campaign`
- verify no other calls use reversed order

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684365458610832aaad570ba0b1e5433