### PR TITLE
Fix wsgi import block

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -8,9 +8,8 @@ sys.path.insert(0, BASE_DIR)
 
 try:
     from app import app as application
-except Exception as e:
-    # Log import errors to Apache error log
-    import traceback
+except Exception:           # keep original traceback logging
+    import traceback, sys
     with open('/tmp/wsgi_error.log', 'w') as f:
         f.write(traceback.format_exc())
     raise


### PR DESCRIPTION
## Summary
- update wsgi import exception handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68436541bfd8832a84b36ada27546a1a